### PR TITLE
nordic_nrf: Increase maximum watchdog timeout value

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/target.cfg
@@ -25,7 +25,7 @@ watchdog.0.base = 0x40018000; // Unused value
 watchdog.0.num_of_tick_per_micro_sec = 1;
 watchdog.0.timeout_in_micro_sec_low = 1000000; // 1.0 secs
 watchdog.0.timeout_in_micro_sec_medium = 2000000;  // 2 secs
-watchdog.0.timeout_in_micro_sec_high = 5000000; // 5 secs
+watchdog.0.timeout_in_micro_sec_high = 600000000; // 60 secs
 watchdog.0.timeout_in_micro_sec_crypto = 18000000; // 18 secs
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/target.cfg
@@ -25,10 +25,10 @@ watchdog.0.base = 0x40018000;
 watchdog.0.num_of_tick_per_micro_sec = 1;
 // The same value should be used for all timeout durations, as the nRF91
 // WDT cannot be reconfigured once it has been started.
-watchdog.0.timeout_in_micro_sec_low = 18000000; // 18 secs
-watchdog.0.timeout_in_micro_sec_medium = 18000000;  // 18 secs
-watchdog.0.timeout_in_micro_sec_high = 18000000; // 18 secs
-watchdog.0.timeout_in_micro_sec_crypto = 18000000; // 18 secs
+watchdog.0.timeout_in_micro_sec_low = 60000000; // 60 secs
+watchdog.0.timeout_in_micro_sec_medium = 60000000;
+watchdog.0.timeout_in_micro_sec_high = 60000000;
+watchdog.0.timeout_in_micro_sec_crypto = 60000000;
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
 nvmem.num =1;


### PR DESCRIPTION
Increase the maximum watchdog timeout value.

Protected Storage Test 403 "Insufficient space check" takes almost
50 seconds to complete on the nordic nrf9160 and nrf5340 SoCs.
Increase the maximum watchdog value to 60 seconds to allow this
testcase to pass.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>
(cherry picked from commit d3d8592962c0d31083d32f91d1a4846753efc0bd)