### PR TITLE
dev-apis: platform: Increase timeout for nRF devs

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/target.cfg
@@ -26,7 +26,7 @@ watchdog.0.num_of_tick_per_micro_sec = 1;
 watchdog.0.timeout_in_micro_sec_low = 1000000; // 1.0 secs
 watchdog.0.timeout_in_micro_sec_medium = 2000000;  // 2 secs
 watchdog.0.timeout_in_micro_sec_high = 600000000; // 60 secs
-watchdog.0.timeout_in_micro_sec_crypto = 18000000; // 18 secs
+watchdog.0.timeout_in_micro_sec_crypto = 90000000; // 90 secs
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
 nvmem.num =1;

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/target.cfg
@@ -25,10 +25,10 @@ watchdog.0.base = 0x40018000;
 watchdog.0.num_of_tick_per_micro_sec = 1;
 // The same value should be used for all timeout durations, as the nRF91
 // WDT cannot be reconfigured once it has been started.
-watchdog.0.timeout_in_micro_sec_low = 60000000; // 60 secs
-watchdog.0.timeout_in_micro_sec_medium = 60000000;
-watchdog.0.timeout_in_micro_sec_high = 60000000;
-watchdog.0.timeout_in_micro_sec_crypto = 60000000;
+watchdog.0.timeout_in_micro_sec_low = 90000000; // 90 secs
+watchdog.0.timeout_in_micro_sec_medium = 90000000;
+watchdog.0.timeout_in_micro_sec_high = 90000000;
+watchdog.0.timeout_in_micro_sec_crypto = 90000000;
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
 nvmem.num =1;


### PR DESCRIPTION
Increase the crypto timeout for the nRF5340/nRF9160 devices.
The crypto test_c016 involves generation of RSA keys with
2048 bit size which takes non-deterministic time and
can sometimes exceed 60 seconds.

Upstream PR:
https://github.com/ARM-software/psa-arch-tests/pull/328

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>