### PR TITLE
Add 'volatile' to all cmsdk device registers

### DIFF
--- a/api-tests/platform/drivers/uart/cmsdk/pal_uart.h
+++ b/api-tests/platform/drivers/uart/cmsdk/pal_uart.h
@@ -36,17 +36,18 @@
 #define CMSDK_UART_INTSTATUS_TXIRQ_Pos  0   /* CMSDK_UART STATUS: TXIRQ Position */
 #define CMSDK_UART_INTSTATUS_TXIRQ_Msk       (0x01ul << CMSDK_UART_INTSTATUS_TXIRQ_Pos)
                                             /* CMSDK_UART STATUS: TXIRQ Mask */
+typedef volatile uint32_t vuint32_t;
 
 /* typedef's */
 typedef struct {
-    uint32_t  DATA;                     /* Offset: 0x000 (R/W) Data Register */
-    uint32_t  STATE;                    /* Offset: 0x004 (R/W) Status state */
-    uint32_t  CTRL;                     /* Offset: 0x008 (R/W) Control Register */
+    vuint32_t DATA;                     /* Offset: 0x000 (R/W) Data Register */
+    vuint32_t STATE;                    /* Offset: 0x004 (R/W) Status state */
+    vuint32_t CTRL;                     /* Offset: 0x008 (R/W) Control Register */
     union {
-        uint32_t INTSTATUS;             /* Offset: 0x00C (R/ ) Interrupt Status Register */
-        uint32_t INTCLEAR;              /* Offset: 0x00C ( /W) Interrupt Clear Register */
+        vuint32_t INTSTATUS;            /* Offset: 0x00C (R/ ) Interrupt Status Register */
+        vuint32_t INTCLEAR;             /* Offset: 0x00C ( /W) Interrupt Clear Register */
     };
-    uint32_t  BAUDDIV;                  /* Offset: 0x010 (R/W) Baud rate divider */
+    vuint32_t BAUDDIV;                  /* Offset: 0x010 (R/W) Baud rate divider */
 } uart_t;
 
 

--- a/api-tests/platform/drivers/watchdog/cmsdk/pal_wd_cmsdk.h
+++ b/api-tests/platform/drivers/watchdog/cmsdk/pal_wd_cmsdk.h
@@ -22,18 +22,20 @@
 
 #define WDOG_TIMER_MAX_VALUE           0xFFFFFFFF
 
+typedef volatile uint32_t vuint32_t;
+
 typedef struct {
-    uint32_t  LOAD;          /* Offset: 0x000 (R/W) Watchdog Load Register */
-    uint32_t  VALUE;         /* Offset: 0x004 (R/ ) Watchdog Value Register */
-    uint32_t  CTRL;          /* Offset: 0x008 (R/W) Watchdog Control Register */
-    uint32_t  INTCLR;        /* Offset: 0x00C ( /W) Watchdog Clear Interrupt Register */
-    uint32_t  RAWINTSTAT;    /* Offset: 0x010 (R/ ) Watchdog Raw Interrupt Status Register */
-    uint32_t  MASKINTSTAT;   /* Offset: 0x014 (R/ ) Watchdog Interrupt Status Register */
-    uint32_t  RESERVED0[762];
-    uint32_t  LOCK;          /* Offset: 0xC00 (R/W) Watchdog Lock Register */
-    uint32_t  RESERVED1[191];
-    uint32_t  ITCR;          /* Offset: 0xF00 (R/W) Watchdog Integration Test Control Register */
-    uint32_t  ITOP;          /* Offset: 0xF04 ( /W) Watchdog Integration Test Output Set Register */
+    vuint32_t LOAD;          /* Offset: 0x000 (R/W) Watchdog Load Register */
+    vuint32_t VALUE;         /* Offset: 0x004 (R/ ) Watchdog Value Register */
+    vuint32_t CTRL;          /* Offset: 0x008 (R/W) Watchdog Control Register */
+    vuint32_t INTCLR;        /* Offset: 0x00C ( /W) Watchdog Clear Interrupt Register */
+    vuint32_t RAWINTSTAT;    /* Offset: 0x010 (R/ ) Watchdog Raw Interrupt Status Register */
+    vuint32_t MASKINTSTAT;   /* Offset: 0x014 (R/ ) Watchdog Interrupt Status Register */
+    vuint32_t RESERVED0[762];
+    vuint32_t LOCK;          /* Offset: 0xC00 (R/W) Watchdog Lock Register */
+    vuint32_t RESERVED1[191];
+    vuint32_t ITCR;          /* Offset: 0xF00 (R/W) Watchdog Integration Test Control Register */
+    vuint32_t ITOP;          /* Offset: 0xF04 ( /W) Watchdog Integration Test Output Set Register */
 } wd_timer_t;
 
 /* WATCHDOG LOAD Register Definitions */


### PR DESCRIPTION
This ensures that GCC 14.3 performs the register accesses in the specified manner instead of reordering or combining them using strd/ldrd instructions.