### PR TITLE
[zep noup] psa-arch-tests: Allow overriding of toolchain file

### DIFF
--- a/api-tests/CMakeLists.txt
+++ b/api-tests/CMakeLists.txt
@@ -635,6 +635,10 @@ add_custom_target(
         COMMAND ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR}/src/${PSA_TARGET_GENERATE_DATABASE}-build/ -- clean
 )
 
+if(NOT DEFINED PSA_TOOLCHAIN_FILE)
+  set(PSA_TOOLCHAIN_FILE ${PSA_ROOT_DIR}/tools/cmake/compiler/${TOOLCHAIN}.cmake)
+endif()
+
 # Check for supported toolchain/s
 if(${TOOLCHAIN} IN_LIST PSA_TOOLCHAIN_SUPPORT)
 	if (DEFINED CROSS_COMPILE)
@@ -642,7 +646,7 @@ if(${TOOLCHAIN} IN_LIST PSA_TOOLCHAIN_SUPPORT)
 			message(FATAL_ERROR "[PSA] : Error: CROSS_COMPILE not supported for this toolchain, supported toolchain are : ${CROSS_COMPILE_TOOLCHAIN_SUPPORT}")
 		endif()
 	endif()
-	include(${PSA_ROOT_DIR}/tools/cmake/compiler/${TOOLCHAIN}.cmake)
+    include(${PSA_TOOLCHAIN_FILE})
 else()
 	message(FATAL_ERROR "[PSA] : Error: Unsupported value for -DTOOLCHAIN=${TOOLCHAIN}, supported toolchain are : ${PSA_TOOLCHAIN_SUPPORT}")
 endif()


### PR DESCRIPTION
The INHERIT.cmake toolchain file that upstream intends us to use is not flexible enough. It does not permit overriding of CMAKE_C_FLAGS for instance as GNUARM.cmake does.

So we allow the file to be overridden such that we can have full flexibility in customizing the toolchain.

This patch is temporary until upstream finds a better solution for toolchain configuration.

(cherry picked from commit d1e57842b835b4a19db09fdf3cf2ec9a8887479f)